### PR TITLE
feat: introduce rule schema, first lint rule, and auto-docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,8 @@ package-lock.json
 .vscode/
 *.swp
 
-docs/
 coverage/
 dist/
 *.tsbuildinfo
-
-Thumbs.db
 *.log
 .env*

--- a/docs/best-practices/const-vs-enum.md
+++ b/docs/best-practices/const-vs-enum.md
@@ -1,0 +1,33 @@
+---
+title: Use const instead of single-value enum
+code: const-vs-enum
+category: best-practices
+vocabularies: https://json-schema.org/draft/2019-09/vocab/validation, https://json-schema.org/draft/2020-12/vocab/validation
+---
+
+## Description
+Promote semantic clarity by replacing a one-item enum with const.
+
+> **Message shown to user:**
+> Single-value enum detected - replace with const.
+
+## Invalid example
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "enum": [
+    "foo"
+  ]
+}
+```
+
+## Valid example
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "const": "foo"
+}
+```
+
+## References
+* <https://json-schema.org/understanding-json-schema/reference/const>

--- a/generate.mjs
+++ b/generate.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const RULE_SCHEMA = "rule.schema.json";
+const RULES_DIR = "rules";
+const DOCS_DIR = "docs";
+
+await fs.mkdir(DOCS_DIR, { recursive: true });
+
+for (const categoryDir of await fs.readdir(RULES_DIR, {
+  withFileTypes: true,
+})) {
+  if (!categoryDir.isDirectory()) continue;
+  const category = categoryDir.name;
+  const ruleDir = path.join(RULES_DIR, category);
+
+  for (const file of await fs.readdir(ruleDir)) {
+    if (!file.endsWith(".json")) continue;
+    const rulePath = path.join(ruleDir, file);
+
+    // Validate rule metadata
+    const { status } = spawnSync(
+      "jsonschema",
+      ["validate", RULE_SCHEMA, rulePath],
+      { stdio: "inherit" }
+    );
+    if (status !== 0) process.exit(status);
+
+    // Generate markdown
+    const rule = JSON.parse(await fs.readFile(rulePath, "utf8"));
+    const outDir = path.join(DOCS_DIR, category);
+    await fs.mkdir(outDir, { recursive: true });
+    const md = render(rule, category);
+    await fs.writeFile(
+      path.join(outDir, `${path.basename(file, ".json")}.md`),
+      md
+    );
+    console.log("✓", rule.code);
+  }
+}
+
+function render(r, cat) {
+  return `---
+title: ${r.title}
+code: ${r.code}
+category: ${cat}
+severity: ${r.severity}
+dialects: ${r.dialects.join(", ")}
+---
+
+## Description
+${r.description}
+
+## Invalid example
+\`\`\`json
+${JSON.stringify(r.invalid[0].schema, null, 2)}
+\`\`\`
+
+## Valid example
+\`\`\`json
+${JSON.stringify(r.valid[0].schema, null, 2)}
+\`\`\`
+
+${
+  r.references?.length
+    ? "## References\n" + r.references.map((u) => `* <${u}>`).join("\n")
+    : ""
+}
+`;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "jsonschema-lint-rules",
   "scripts": {
     "build": "node generate.mjs",
-    "validate:rules": "jsonschema validate rule.schema.json \"rules/**/*.json\""
+    "validate:rules": "jsonschema validate rule.schema.json rules/**/*.json"
   },
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "jsonschema-lint-rules",
-    "version": "0.1.0",
-    "type": "module",
-    "license": "MIT",
-    "scripts": {
-        "validate:rules": "jsonschema validate rule.schema.json \"rules/**/*.json\"",
-        "build": "node generate.mjs"
-    },
-    "devDependencies": {
-        "@sourcemeta/jsonschema": "^9.3.1"
-    }
+  "type": "module",
+  "devDependencies": {
+    "@sourcemeta/jsonschema": "^9.3.1"
+  },
+  "license": "MIT",
+  "name": "jsonschema-lint-rules",
+  "scripts": {
+    "build": "node generate.mjs",
+    "validate:rules": "jsonschema validate rule.schema.json \"rules/**/*.json\""
+  },
+  "version": "0.1.0"
 }

--- a/rule.schema.json
+++ b/rule.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/rule.schema.json",
+  "title": "JSON-Schema lint rule metadata",
+  "type": "object",
+  "required": [
+    "code",
+    "title",
+    "description",
+    "dialects",
+    "severity",
+    "invalid",
+    "valid"
+  ],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "code": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_]+$"
+    },
+    "dialects": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [ "draft4", "draft6", "draft7", "2019-09", "2020-12" ]
+      }
+    },
+    "invalid": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "schema" ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "schema": {}
+        },
+        "additionalProperties": false
+      }
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "severity": {
+      "type": "string",
+      "enum": [ "info", "warning", "error" ]
+    },
+    "valid": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [ "schema" ],
+        "properties": {
+          "schema": {}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/rule.schema.json
+++ b/rule.schema.json
@@ -4,11 +4,10 @@
   "title": "JSON-Schema lint rule metadata",
   "type": "object",
   "required": [
-    "code",
     "title",
     "description",
-    "dialects",
-    "severity",
+    "message",
+    "vocabularies",
     "invalid",
     "valid"
   ],
@@ -19,30 +18,19 @@
     "description": {
       "type": "string"
     },
-    "code": {
-      "type": "string",
-      "pattern": "^[A-Z0-9_]+$"
-    },
-    "dialects": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [ "draft4", "draft6", "draft7", "2019-09", "2020-12" ]
-      }
-    },
     "invalid": {
       "type": "array",
       "items": {
         "type": "object",
         "required": [ "schema" ],
         "properties": {
-          "message": {
-            "type": "string"
-          },
           "schema": {}
         },
         "additionalProperties": false
       }
+    },
+    "message": {
+      "type": "string"
     },
     "references": {
       "type": "array",
@@ -50,10 +38,6 @@
         "type": "string",
         "format": "uri"
       }
-    },
-    "severity": {
-      "type": "string",
-      "enum": [ "info", "warning", "error" ]
     },
     "valid": {
       "type": "array",
@@ -64,6 +48,13 @@
           "schema": {}
         },
         "additionalProperties": false
+      }
+    },
+    "vocabularies": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^https://json-schema\\.org/draft/(4|6|7|2019-09|2020-12)/vocab/[a-z-]+$"
       }
     }
   },

--- a/rules/best-practices/const-vs-enum.json
+++ b/rules/best-practices/const-vs-enum.json
@@ -1,25 +1,28 @@
 {
   "title": "Use const instead of single-value enum",
   "description": "Promote semantic clarity by replacing a one-item enum with const.",
-  "code": "CONST_INSTEAD_OF_ENUM",
-  "dialects": [ "draft4", "draft6", "draft7", "2019-09", "2020-12" ],
   "invalid": [
     {
-      "message": "Single-value enum; use const instead.",
       "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [ "foo" ]
       }
     }
   ],
+  "message": "Single-value enum detected - replace with const.",
   "references": [
     "https://json-schema.org/understanding-json-schema/reference/const"
   ],
-  "severity": "warning",
   "valid": [
     {
       "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "const": "foo"
       }
     }
+  ],
+  "vocabularies": [
+    "https://json-schema.org/draft/2019-09/vocab/validation",
+    "https://json-schema.org/draft/2020-12/vocab/validation"
   ]
 }

--- a/rules/best-practices/const-vs-enum.json
+++ b/rules/best-practices/const-vs-enum.json
@@ -1,0 +1,25 @@
+{
+  "title": "Use const instead of single-value enum",
+  "description": "Promote semantic clarity by replacing a one-item enum with const.",
+  "code": "CONST_INSTEAD_OF_ENUM",
+  "dialects": [ "draft4", "draft6", "draft7", "2019-09", "2020-12" ],
+  "invalid": [
+    {
+      "message": "Single-value enum; use const instead.",
+      "schema": {
+        "enum": [ "foo" ]
+      }
+    }
+  ],
+  "references": [
+    "https://json-schema.org/understanding-json-schema/reference/const"
+  ],
+  "severity": "warning",
+  "valid": [
+    {
+      "schema": {
+        "const": "foo"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Adds **`rule.schema.json`** – the single source-of-truth JSON Schema for every lint-rule file.  
- Adds **`generate.mjs`** – build script that  
  1. validates each rule with Sourcemeta’s CLI, and  
  2. converts them into pretty Markdown under `docs/`.
- Commits the first rule: `rules/best-practices/const-vs-enum.json`.
- Commits auto-generated documentation for that rule (`docs/best-practices/const-vs-enum.md`).
- Adds NPM scripts  
  - `validate:rules` – schema-checks all rules  
  - `build` – validate **+** regenerate docs
- Tracks `docs/` in Git to make rendered output reviewable.

**Screenshots/videos:**

[Screencast from 2025-05-15 22-26-29.webm](https://github.com/user-attachments/assets/3758bb10-2613-423a-8308-a9ca1b5b20ab)


