### PR TITLE
feat(rule): add “enum-no-extra-keywords” lint rule

### DIFF
--- a/.github/workflows/rule-docs.yml
+++ b/.github/workflows/rule-docs.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/rules/enum-no-extra-keywords.json
+++ b/rules/enum-no-extra-keywords.json
@@ -1,0 +1,48 @@
+{
+  "title": "Avoid combining enum with other validation keywords",
+  "description": "`enum` fully defines allowed values; adding type/length/number constraints is redundant and can even contradict the enum.",
+  "examples": [
+    {
+      "after": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "enum": [ "one", "two" ]
+      },
+      "before": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+        "enum": [ "one", "two" ],
+        "minLength": 3
+      },
+      "doc": true,
+      "tags": [ "basic" ]
+    },
+    {
+      "before": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "enum": [ 1, 2, 3 ],
+        "minimum": 0
+      }
+    },
+    {
+      "before": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "integer",
+        "enum": [ 10 ],
+        "maximum": 100,
+        "multipleOf": 2
+      }
+    }
+  ],
+  "categories": [ "correctness", "readability" ],
+  "dialects": {
+    "2019-09": [ "enum" ],
+    "2020-12": [ "enum" ],
+    "draft4": [ "enum" ],
+    "draft6": [ "enum" ],
+    "draft7": [ "enum" ]
+  },
+  "message": "Remove complementary validation keywords when an enum is present.",
+  "references": [
+    "https://github.com/orgs/json-schema-orgs/discussions/323#discussioncomment-4898765"
+  ]
+}


### PR DESCRIPTION
What kind of change does this PR introduce?

* **Adds `rules/enum-no-extra-keywords.json`**  
  *New lint rule*: “Avoid combining `enum` with other validation keywords.”  
  Includes `before/after` example
